### PR TITLE
return dispatch returned value

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -83,6 +83,6 @@ export const versionedPromiseActionMiddleware = versionSelector => store => next
       return;
     }
 
-    next(action[CHANGE_VERSION] ? setChangeVersion(action) : action);
+    return next(action[CHANGE_VERSION] ? setChangeVersion(action) : action);
   }
 };


### PR DESCRIPTION
middleware should return the value returned by "next" function, so we can capture a probably promise returned and do some thens and catchs.